### PR TITLE
Preparing for the 4.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,170 +1,192 @@
 # Changelog
 
-## [3.0.1](https://github.com/samvera-labs/bixby/tree/3.0.1) (2020-06-16)
+## [4.0.0](https://github.com/samvera/bixby/tree/v4.0.0) (2022-03-30)
 
-[Full Changelog](https://github.com/samvera-labs/bixby/compare/v3.0.0...3.0.1)
-
-**Merged pull requests:**
-
-- Removes IndentationConsistency supported styles [\#45](https://github.com/samvera-labs/bixby/pull/45) ([rotated8](https://github.com/rotated8))
-- allow non-ascii characters in comments [\#44](https://github.com/samvera-labs/bixby/pull/44) ([no-reply](https://github.com/no-reply))
-
-## [v3.0.0](https://github.com/samvera-labs/bixby/tree/v3.0.0) (2020-06-10)
-
-[Full Changelog](https://github.com/samvera-labs/bixby/compare/v3.0.0.pre3...v3.0.0)
+[Full Changelog](https://github.com/samvera/bixby/compare/v3.0.2...v4.0.0)
 
 **Merged pull requests:**
 
-- Prep for 3.0.0 release [\#43](https://github.com/samvera-labs/bixby/pull/43) ([bess](https://github.com/bess))
-- Prep for 3.0.0.pre3 release [\#42](https://github.com/samvera-labs/bixby/pull/42) ([bess](https://github.com/bess))
+- Upgrade to rubocop 1.x [\#57](https://github.com/samvera/bixby/pull/57) ([cjcolvar](https://github.com/cjcolvar))
+- Updated CONTRIBUTING [\#55](https://github.com/samvera/bixby/pull/55) ([kelynch](https://github.com/kelynch))
+- Updated README [\#54](https://github.com/samvera/bixby/pull/54) ([kelynch](https://github.com/kelynch))
+- Preparing the Gem for promotion to Core Component [\#60](https://github.com/samvera/bixby/pull/60) ([jrgriffiniii](https://github.com/jrgriffiniii))
+- Adding the CI branch name test for `master` [\#61](https://github.com/samvera/bixby/pull/61) ([kelynch](https://github.com/kelynch))
+- Make new issue link work now [\#63](https://github.com/samvera/bixby/pull/63) ([cjcolvar](https://github.com/cjcolvar))
+- Fix reference in README to main branch [\#66](https://github.com/samvera/bixby/pull/66) ([bess](https://github.com/bess))
 
-## [v3.0.0.pre3](https://github.com/samvera-labs/bixby/tree/v3.0.0.pre3) (2020-06-10)
+## [3.0.2](https://github.com/samvera/bixby/tree/v3.0.2) (2020-09-16)
 
-[Full Changelog](https://github.com/samvera-labs/bixby/compare/v3.0.0.pre2...v3.0.0.pre3)
-
-**Merged pull requests:**
-
-- Disable Rails/DynamicFindBy [\#41](https://github.com/samvera-labs/bixby/pull/41) ([bess](https://github.com/bess))
-
-## [v3.0.0.pre2](https://github.com/samvera-labs/bixby/tree/v3.0.0.pre2) (2020-06-10)
-
-[Full Changelog](https://github.com/samvera-labs/bixby/compare/v3.0.0.pre1...v3.0.0.pre2)
+[Full Changelog](https://github.com/samvera/bixby/compare/v3.0.1...v3.0.2)
 
 **Merged pull requests:**
 
-- Prep for 3.0.0.pre2 release [\#40](https://github.com/samvera-labs/bixby/pull/40) ([bess](https://github.com/bess))
-- 3.0.0 fixup [\#39](https://github.com/samvera-labs/bixby/pull/39) ([no-reply](https://github.com/no-reply))
+- Setting rubocop-ast to ~> 0.3.0 [\#47](https://github.com/samvera/bixby/pull/47) ([jeremyf](https://github.com/jeremyf))
 
-## [v3.0.0.pre1](https://github.com/samvera-labs/bixby/tree/v3.0.0.pre1) (2020-06-10)
+## [3.0.1](https://github.com/samvera/bixby/tree/3.0.1) (2020-06-16)
 
-[Full Changelog](https://github.com/samvera-labs/bixby/compare/v3.0.0.pre.pre1...v3.0.0.pre1)
+[Full Changelog](https://github.com/samvera/bixby/compare/v3.0.0...3.0.1)
 
 **Merged pull requests:**
 
-- Fix gem version [\#38](https://github.com/samvera-labs/bixby/pull/38) ([bess](https://github.com/bess))
+- Removes IndentationConsistency supported styles [\#45](https://github.com/samvera/bixby/pull/45) ([rotated8](https://github.com/rotated8))
+- allow non-ascii characters in comments [\#44](https://github.com/samvera/bixby/pull/44) ([no-reply](https://github.com/no-reply))
 
-## [v3.0.0.pre.pre1](https://github.com/samvera-labs/bixby/tree/v3.0.0.pre.pre1) (2020-06-10)
+## [v3.0.0](https://github.com/samvera/bixby/tree/v3.0.0) (2020-06-10)
 
-[Full Changelog](https://github.com/samvera-labs/bixby/compare/v2.1.0...v3.0.0.pre.pre1)
+[Full Changelog](https://github.com/samvera/bixby/compare/v3.0.0.pre3...v3.0.0)
+
+**Merged pull requests:**
+
+- Prep for 3.0.0 release [\#43](https://github.com/samvera/bixby/pull/43) ([bess](https://github.com/bess))
+- Prep for 3.0.0.pre3 release [\#42](https://github.com/samvera/bixby/pull/42) ([bess](https://github.com/bess))
+
+## [v3.0.0.pre3](https://github.com/samvera/bixby/tree/v3.0.0.pre3) (2020-06-10)
+
+[Full Changelog](https://github.com/samvera/bixby/compare/v3.0.0.pre2...v3.0.0.pre3)
+
+**Merged pull requests:**
+
+- Disable Rails/DynamicFindBy [\#41](https://github.com/samvera/bixby/pull/41) ([bess](https://github.com/bess))
+
+## [v3.0.0.pre2](https://github.com/samvera/bixby/tree/v3.0.0.pre2) (2020-06-10)
+
+[Full Changelog](https://github.com/samvera/bixby/compare/v3.0.0.pre1...v3.0.0.pre2)
+
+**Merged pull requests:**
+
+- Prep for 3.0.0.pre2 release [\#40](https://github.com/samvera/bixby/pull/40) ([bess](https://github.com/bess))
+- 3.0.0 fixup [\#39](https://github.com/samvera/bixby/pull/39) ([no-reply](https://github.com/no-reply))
+
+## [v3.0.0.pre1](https://github.com/samvera/bixby/tree/v3.0.0.pre1) (2020-06-10)
+
+[Full Changelog](https://github.com/samvera/bixby/compare/v3.0.0.pre.pre1...v3.0.0.pre1)
+
+**Merged pull requests:**
+
+- Fix gem version [\#38](https://github.com/samvera/bixby/pull/38) ([bess](https://github.com/bess))
+
+## [v3.0.0.pre.pre1](https://github.com/samvera/bixby/tree/v3.0.0.pre.pre1) (2020-06-10)
+
+[Full Changelog](https://github.com/samvera/bixby/compare/v2.1.0...v3.0.0.pre.pre1)
 
 **Implemented enhancements:**
 
-- Request to promote this Gem to samvera [\#33](https://github.com/samvera-labs/bixby/issues/33)
+- Request to promote this Gem to samvera [\#33](https://github.com/samvera/bixby/issues/33)
 
 **Merged pull requests:**
 
-- Prep for 3.0.0-pre1 release [\#37](https://github.com/samvera-labs/bixby/pull/37) ([bess](https://github.com/bess))
-- Prepares the Gem for promotion [\#34](https://github.com/samvera-labs/bixby/pull/34) ([jrgriffiniii](https://github.com/jrgriffiniii))
+- Prep for 3.0.0-pre1 release [\#37](https://github.com/samvera/bixby/pull/37) ([bess](https://github.com/bess))
+- Prepares the Gem for promotion [\#34](https://github.com/samvera/bixby/pull/34) ([jrgriffiniii](https://github.com/jrgriffiniii))
 
-## [v2.1.0](https://github.com/samvera-labs/bixby/tree/v2.1.0) (2020-06-09)
+## [v2.1.0](https://github.com/samvera/bixby/tree/v2.1.0) (2020-06-09)
 
-[Full Changelog](https://github.com/samvera-labs/bixby/compare/v2.0.0...v2.1.0)
+[Full Changelog](https://github.com/samvera/bixby/compare/v2.0.0...v2.1.0)
 
 **Merged pull requests:**
 
-- Prep for 2.1.0 release [\#36](https://github.com/samvera-labs/bixby/pull/36) ([bess](https://github.com/bess))
-- Upgrade rubocop and dependencies [\#35](https://github.com/samvera-labs/bixby/pull/35) ([bess](https://github.com/bess))
-- Prep for 2.0 release [\#31](https://github.com/samvera-labs/bixby/pull/31) ([bess](https://github.com/bess))
+- Prep for 2.1.0 release [\#36](https://github.com/samvera/bixby/pull/36) ([bess](https://github.com/bess))
+- Upgrade rubocop and dependencies [\#35](https://github.com/samvera/bixby/pull/35) ([bess](https://github.com/bess))
+- Prep for 2.0 release [\#31](https://github.com/samvera/bixby/pull/31) ([bess](https://github.com/bess))
 
-## [v2.0.0](https://github.com/samvera-labs/bixby/tree/v2.0.0) (2019-12-10)
+## [v2.0.0](https://github.com/samvera/bixby/tree/v2.0.0) (2019-12-10)
 
-[Full Changelog](https://github.com/samvera-labs/bixby/compare/v2.0.0.pre.beta1...v2.0.0)
+[Full Changelog](https://github.com/samvera/bixby/compare/v2.0.0.pre.beta1...v2.0.0)
 
 **Closed issues:**
 
-- Upgrade for new rubocop [\#26](https://github.com/samvera-labs/bixby/issues/26)
-- Update rubocop-rspec [\#25](https://github.com/samvera-labs/bixby/issues/25)
-- Lint/BlockAlignment has the wrong namespace - should be Layout [\#24](https://github.com/samvera-labs/bixby/issues/24)
-- Add Lint/RescueWithoutErrorClass [\#23](https://github.com/samvera-labs/bixby/issues/23)
+- Upgrade for new rubocop [\#26](https://github.com/samvera/bixby/issues/26)
+- Update rubocop-rspec [\#25](https://github.com/samvera/bixby/issues/25)
+- Lint/BlockAlignment has the wrong namespace - should be Layout [\#24](https://github.com/samvera/bixby/issues/24)
+- Add Lint/RescueWithoutErrorClass [\#23](https://github.com/samvera/bixby/issues/23)
 
 **Merged pull requests:**
 
-- Skipping node\_modules directory when running cops [\#30](https://github.com/samvera-labs/bixby/pull/30) ([cgalarza](https://github.com/cgalarza))
+- Skipping node\_modules directory when running cops [\#30](https://github.com/samvera/bixby/pull/30) ([cgalarza](https://github.com/cgalarza))
 
-## [v2.0.0.pre.beta1](https://github.com/samvera-labs/bixby/tree/v2.0.0.pre.beta1) (2019-02-14)
+## [v2.0.0.pre.beta1](https://github.com/samvera/bixby/tree/v2.0.0.pre.beta1) (2019-02-14)
 
-[Full Changelog](https://github.com/samvera-labs/bixby/compare/1.0.0...v2.0.0.pre.beta1)
-
-**Merged pull requests:**
-
-- Bixby 2.0 [\#28](https://github.com/samvera-labs/bixby/pull/28) ([no-reply](https://github.com/no-reply))
-- Bump version to 1.0.0-rc1 [\#21](https://github.com/samvera-labs/bixby/pull/21) ([no-reply](https://github.com/no-reply))
-
-## [1.0.0](https://github.com/samvera-labs/bixby/tree/1.0.0) (2018-02-13)
-
-[Full Changelog](https://github.com/samvera-labs/bixby/compare/v1.0.0-rc1...1.0.0)
+[Full Changelog](https://github.com/samvera/bixby/compare/1.0.0...v2.0.0.pre.beta1)
 
 **Merged pull requests:**
 
-- Prepare Release 1.0.0 [\#22](https://github.com/samvera-labs/bixby/pull/22) ([no-reply](https://github.com/no-reply))
+- Bixby 2.0 [\#28](https://github.com/samvera/bixby/pull/28) ([no-reply](https://github.com/no-reply))
+- Bump version to 1.0.0-rc1 [\#21](https://github.com/samvera/bixby/pull/21) ([no-reply](https://github.com/no-reply))
 
-## [v1.0.0-rc1](https://github.com/samvera-labs/bixby/tree/v1.0.0-rc1) (2018-02-09)
+## [1.0.0](https://github.com/samvera/bixby/tree/1.0.0) (2018-02-13)
 
-[Full Changelog](https://github.com/samvera-labs/bixby/compare/v0.3.1...v1.0.0-rc1)
+[Full Changelog](https://github.com/samvera/bixby/compare/v1.0.0-rc1...1.0.0)
+
+**Merged pull requests:**
+
+- Prepare Release 1.0.0 [\#22](https://github.com/samvera/bixby/pull/22) ([no-reply](https://github.com/no-reply))
+
+## [v1.0.0-rc1](https://github.com/samvera/bixby/tree/v1.0.0-rc1) (2018-02-09)
+
+[Full Changelog](https://github.com/samvera/bixby/compare/v0.3.1...v1.0.0-rc1)
 
 **Closed issues:**
 
-- Disable `RSpec/MulitpleExpectations` [\#19](https://github.com/samvera-labs/bixby/issues/19)
-- Add tmp dir to AllCops exclusion [\#18](https://github.com/samvera-labs/bixby/issues/18)
-- Warning: unrecognized cop Naming/BinaryOperatorParameter found in ~/.gem/ruby/2.4.2/gems/bixby-0.3.0/bixby\_default.yml [\#14](https://github.com/samvera-labs/bixby/issues/14)
-- Resolve new cops/changes is in rubocop-rspec 0.18.0. [\#11](https://github.com/samvera-labs/bixby/issues/11)
-- Resolve new cops/changes in RuboCop 0.50.0 [\#10](https://github.com/samvera-labs/bixby/issues/10)
-- Bixby not compatible with latest Rubocop [\#6](https://github.com/samvera-labs/bixby/issues/6)
+- Disable `RSpec/MulitpleExpectations` [\#19](https://github.com/samvera/bixby/issues/19)
+- Add tmp dir to AllCops exclusion [\#18](https://github.com/samvera/bixby/issues/18)
+- Warning: unrecognized cop Naming/BinaryOperatorParameter found in ~/.gem/ruby/2.4.2/gems/bixby-0.3.0/bixby\_default.yml [\#14](https://github.com/samvera/bixby/issues/14)
+- Resolve new cops/changes is in rubocop-rspec 0.18.0. [\#11](https://github.com/samvera/bixby/issues/11)
+- Resolve new cops/changes in RuboCop 0.50.0 [\#10](https://github.com/samvera/bixby/issues/10)
+- Bixby not compatible with latest Rubocop [\#6](https://github.com/samvera/bixby/issues/6)
 
 **Merged pull requests:**
 
-- Support newer versions of `rubocop`, `rubocop-rspec`, and Ruby [\#20](https://github.com/samvera-labs/bixby/pull/20) ([no-reply](https://github.com/no-reply))
-- Remove Lint/InvalidCharacterLiteral, fixes \#15 [\#16](https://github.com/samvera-labs/bixby/pull/16) ([hackmastera](https://github.com/hackmastera))
-- Update READEME.md to discuss versioning strategy [\#13](https://github.com/samvera-labs/bixby/pull/13) ([no-reply](https://github.com/no-reply))
-- Lock versions to `rubocop` 0.50.0 and `rubocop-rspec` 1.18.0 [\#12](https://github.com/samvera-labs/bixby/pull/12) ([no-reply](https://github.com/no-reply))
+- Support newer versions of `rubocop`, `rubocop-rspec`, and Ruby [\#20](https://github.com/samvera/bixby/pull/20) ([no-reply](https://github.com/no-reply))
+- Remove Lint/InvalidCharacterLiteral, fixes \#15 [\#16](https://github.com/samvera/bixby/pull/16) ([hackmastera](https://github.com/hackmastera))
+- Update READEME.md to discuss versioning strategy [\#13](https://github.com/samvera/bixby/pull/13) ([no-reply](https://github.com/no-reply))
+- Lock versions to `rubocop` 0.50.0 and `rubocop-rspec` 1.18.0 [\#12](https://github.com/samvera/bixby/pull/12) ([no-reply](https://github.com/no-reply))
 
-## [v0.3.1](https://github.com/samvera-labs/bixby/tree/v0.3.1) (2017-10-04)
+## [v0.3.1](https://github.com/samvera/bixby/tree/v0.3.1) (2017-10-04)
 
-[Full Changelog](https://github.com/samvera-labs/bixby/compare/v0.3.0...v0.3.1)
+[Full Changelog](https://github.com/samvera/bixby/compare/v0.3.0...v0.3.1)
 
 **Closed issues:**
 
-- Error: The `Lint/InvalidCharacterLiteral` cop has been removed since it was never being actually triggered. \(obsolete configuration found in /home/ubuntu/valkyrie/valkyrie/vendor/valk\_bundle/ruby/2.3.0/gems/bixby-0.3.0/bixby\_default.yml, please update it\) [\#15](https://github.com/samvera-labs/bixby/issues/15)
+- Error: The `Lint/InvalidCharacterLiteral` cop has been removed since it was never being actually triggered. \(obsolete configuration found in /home/ubuntu/valkyrie/valkyrie/vendor/valk\_bundle/ruby/2.3.0/gems/bixby-0.3.0/bixby\_default.yml, please update it\) [\#15](https://github.com/samvera/bixby/issues/15)
 
 **Merged pull requests:**
 
-- Remove Lint/InvalidCharacterLiteral, fixes \#15 [\#17](https://github.com/samvera-labs/bixby/pull/17) ([hackmastera](https://github.com/hackmastera))
+- Remove Lint/InvalidCharacterLiteral, fixes \#15 [\#17](https://github.com/samvera/bixby/pull/17) ([hackmastera](https://github.com/hackmastera))
 
-## [v0.3.0](https://github.com/samvera-labs/bixby/tree/v0.3.0) (2017-10-03)
+## [v0.3.0](https://github.com/samvera/bixby/tree/v0.3.0) (2017-10-03)
 
-[Full Changelog](https://github.com/samvera-labs/bixby/compare/v0.2.2...v0.3.0)
+[Full Changelog](https://github.com/samvera/bixby/compare/v0.2.2...v0.3.0)
 
 **Merged pull requests:**
 
-- Prepare Release v0.3.0 [\#9](https://github.com/samvera-labs/bixby/pull/9) ([no-reply](https://github.com/no-reply))
-- Upgrade for RuboCop 0.50.0 compatibility [\#8](https://github.com/samvera-labs/bixby/pull/8) ([no-reply](https://github.com/no-reply))
-- Allow deeper group nesting in RSpec [\#7](https://github.com/samvera-labs/bixby/pull/7) ([no-reply](https://github.com/no-reply))
+- Prepare Release v0.3.0 [\#9](https://github.com/samvera/bixby/pull/9) ([no-reply](https://github.com/no-reply))
+- Upgrade for RuboCop 0.50.0 compatibility [\#8](https://github.com/samvera/bixby/pull/8) ([no-reply](https://github.com/no-reply))
+- Allow deeper group nesting in RSpec [\#7](https://github.com/samvera/bixby/pull/7) ([no-reply](https://github.com/no-reply))
 
-## [v0.2.2](https://github.com/samvera-labs/bixby/tree/v0.2.2) (2017-08-07)
+## [v0.2.2](https://github.com/samvera/bixby/tree/v0.2.2) (2017-08-07)
 
-[Full Changelog](https://github.com/samvera-labs/bixby/compare/v0.2.1...v0.2.2)
+[Full Changelog](https://github.com/samvera/bixby/compare/v0.2.1...v0.2.2)
 
 **Closed issues:**
 
-- Should we allow long blocks in CatalogController? [\#3](https://github.com/samvera-labs/bixby/issues/3)
+- Should we allow long blocks in CatalogController? [\#3](https://github.com/samvera/bixby/issues/3)
 
 **Merged pull requests:**
 
-- Ignore block and class length on CatalogController [\#5](https://github.com/samvera-labs/bixby/pull/5) ([no-reply](https://github.com/no-reply))
-- Include 'Capfile' in excluded filenames [\#4](https://github.com/samvera-labs/bixby/pull/4) ([mark-dce](https://github.com/mark-dce))
+- Ignore block and class length on CatalogController [\#5](https://github.com/samvera/bixby/pull/5) ([no-reply](https://github.com/no-reply))
+- Include 'Capfile' in excluded filenames [\#4](https://github.com/samvera/bixby/pull/4) ([mark-dce](https://github.com/mark-dce))
 
-## [v0.2.1](https://github.com/samvera-labs/bixby/tree/v0.2.1) (2017-06-01)
+## [v0.2.1](https://github.com/samvera/bixby/tree/v0.2.1) (2017-06-01)
 
-[Full Changelog](https://github.com/samvera-labs/bixby/compare/v0.2.0...v0.2.1)
+[Full Changelog](https://github.com/samvera/bixby/compare/v0.2.0...v0.2.1)
 
 **Merged pull requests:**
 
-- Add bundler release tasks for easier gem management [\#2](https://github.com/samvera-labs/bixby/pull/2) ([bess](https://github.com/bess))
-- Rubocop 0 49 fixes [\#1](https://github.com/samvera-labs/bixby/pull/1) ([bess](https://github.com/bess))
+- Add bundler release tasks for easier gem management [\#2](https://github.com/samvera/bixby/pull/2) ([bess](https://github.com/bess))
+- Rubocop 0 49 fixes [\#1](https://github.com/samvera/bixby/pull/1) ([bess](https://github.com/bess))
 
-## [v0.2.0](https://github.com/samvera-labs/bixby/tree/v0.2.0) (2017-03-30)
+## [v0.2.0](https://github.com/samvera/bixby/tree/v0.2.0) (2017-03-30)
 
-[Full Changelog](https://github.com/samvera-labs/bixby/compare/8f95541b23cfda44c8a89704127696262284215a...v0.2.0)
+[Full Changelog](https://github.com/samvera/bixby/compare/8f95541b23cfda44c8a89704127696262284215a...v0.2.0)
 
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ further details.
 ### Reporting Issues
 
 * Make sure you have a [GitHub account](https://github.com/signup/free)
-* Submit a [Github issue](https://github.com/samvera-labs/bixby/issues/) by:
+* Submit a [Github issue](https://github.com/samvera/bixby/issues/) by:
   * Clearly describing the issue
     * Provide a descriptive summary
     * Explain the expected behavior

--- a/bixby.gemspec
+++ b/bixby.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'bixby'
   spec.require_paths = ['lib']
 
-  spec.version       = '3.0.2'
+  spec.version       = '4.0.0'
   spec.license       = 'Apache-2.0'
 
   spec.required_ruby_version = '>= 2.5'


### PR DESCRIPTION
Resolves #67 by addressing the following:

- Preparing for the 4.0.0 release
- Updating the CHANGELOG for the 4.0.0 and 3.0.2
- Replacing `samvera-labs` with `samvera` in CHANGELOG and CONTRIBUTING