### PR TITLE
Removes Lint/UselessElseWithoutRescue cop.

### DIFF
--- a/bixby.gemspec
+++ b/bixby.gemspec
@@ -12,10 +12,10 @@ Gem::Specification.new do |spec|
   spec.name          = 'bixby'
   spec.require_paths = ['lib']
 
-  spec.version       = '4.0.0'
+  spec.version       = '5.0.0'
   spec.license       = 'Apache-2.0'
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_dependency 'rubocop', '>= 1', '< 2'
   spec.add_dependency 'rubocop-ast'

--- a/bixby_default.yml
+++ b/bixby_default.yml
@@ -1,7 +1,7 @@
 require: rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   DisabledByDefault: true
   DisplayCopNames: true
   Exclude:

--- a/bixby_default.yml
+++ b/bixby_default.yml
@@ -801,9 +801,6 @@ Lint/UselessAssignment:
 Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: true
 
-Lint/UselessElseWithoutRescue:
-  Enabled: true
-
 Lint/UselessSetterCall:
   Enabled: true
 


### PR DESCRIPTION
That cop has been removed in Rubocop v1.2.9+. 

See issue: https://github.com/samvera/bixby/issues/71