### PR TITLE
Updating the Product Owner information in preparation for the 2022 autumn request for maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 Bixby: I'd buy that for a dollar!
 =================================
 
-[![Apache 2.0 License](http://img.shields.io/badge/APACHE2-license-blue.svg)](./LICENSE)
+Code:
 [![Gem Version](https://badge.fury.io/rb/bixby.svg)](https://badge.fury.io/rb/bixby)
+[![Build Status](https://circleci.com/gh/samvera/bixby.svg?style=svg)](https://circleci.com/gh/samvera/bixby)
 
-[Jump in on Slack](http://slack.samvera.org/)
+Docs:
+[![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
+[![Apache 2.0 License](http://img.shields.io/badge/APACHE2-license-blue.svg)](./LICENSE)
+
+Community Support: [![Samvera Community Slack](https://img.shields.io/badge/samvera-slack-blueviolet)](http://slack.samvera.org/)
 
 <p align="left">
   <img src="logo/murphy.jpg" alt="Murphy Sketch"/>
@@ -16,11 +21,13 @@ Bixby is a Ruby Gem containing the default configuration settings for [RuboCop](
 
 ## Product Owner & Maintenance
 
-Bixby is a Core Component of the Samvera community. The documentation for what this means can be found [here](http://samvera.github.io/core_components.html#requirements-for-a-core-component).
+`bixby` was a Core Component of the Samvera Community. Given a decline in available labor required for maintenance, this project no longer has a dedicated Product Owner. The documentation for what this means can be found [here](http://samvera.github.io/core_components.html#requirements-for-a-core-component).
 
 ### Product Owner
 
-[jrgriffiniii](https://github.com/jrgriffiniii)
+**Vacant**
+
+_Until a Product Owner has been identified, we ask that you please direct all requests for support, bug reports, and general questions to the [`#dev` Channel on the Samvera Slack](https://samvera.slack.com/app_redirect?channel=dev)._
 
 # Help
 


### PR DESCRIPTION
This is necessary in order to request from the community renewed efforts for maintenance, and to direct those outside of the community to the Samvera Slack.